### PR TITLE
fix: correct Button import path

### DIFF
--- a/src/artifacts/readability.tsx
+++ b/src/artifacts/readability.tsx
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Button } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { AlertCircle, BookOpen, Hash, Grid, Search } from 'lucide-react';
 
 const TextAnalysisTool = () => {


### PR DESCRIPTION
## Summary
- correct the Button component import path in `readability.tsx`

## Testing
- `npm run lint` *(fails: couldn't find config)*
- `npm test` *(fails: missing script)*
